### PR TITLE
rename Playground to Examples

### DIFF
--- a/docs/components/ns-card.md
+++ b/docs/components/ns-card.md
@@ -178,5 +178,5 @@ More details on how to use the ns-pill can be found on the [ns-pill documentatio
 ## Related links
 
 * [ns-pill](components/ns-pill.md)
-* [ns-card section panel](https://britishgas.co.uk/nucleus/demo/index.html?path=/story/playground-panels--section-cards).
-* [ns-card support panel](https://britishgas.co.uk/nucleus/demo/index.html?path=/story/playground-panels--support-image-cards).
+* [ns-card section panel](https://britishgas.co.uk/nucleus/demo/index.html?path=/story/examples-panels--section-cards).
+* [ns-card support panel](https://britishgas.co.uk/nucleus/demo/index.html?path=/story/examples-panels--support-image-cards).

--- a/docs/components/ns-caveat.md
+++ b/docs/components/ns-caveat.md
@@ -73,4 +73,4 @@ Caveats link to content in the page, providing more information about legality a
 ## Related links
 
 * [ns-caveat component in Storybook](https://britishgas.co.uk/nucleus/demo/index.html?path=/story/ns-caveat--caveat).
-* [Homepage example in Storybook](https://britishgas.co.uk/nucleus/demo/index.html?path=/story/playground-homepage--2019-01).
+* [Homepage example in Storybook](https://britishgas.co.uk/nucleus/demo/index.html?path=/story/examples-homepage--2019-01).

--- a/docs/components/ns-cta.md
+++ b/docs/components/ns-cta.md
@@ -103,4 +103,4 @@ You can see the live example of the loading state on [storybook](https://www.bri
 
 ## Related links
 
-* [CTA examples in the homepage](https://britishgas.co.uk/nucleus/demo/index.html?path=/story/playground-homepage--2019-01).
+* [CTA examples in the homepage](https://britishgas.co.uk/nucleus/demo/index.html?path=/story/examples-homepage--2019-01).

--- a/docs/components/ns-video.md
+++ b/docs/components/ns-video.md
@@ -58,4 +58,4 @@ British Gas creates many videos to engage customers. This component allows havin
 
 ## Related links
 
-* [https://britishgas.co.uk/nucleus/demo/index.html?path=/story/playground-panels--lockup-video-panel](https://britishgas.co.uk/nucleus/demo/index.html?path=/story/playground-panels--lockup-video-panel).
+* [https://britishgas.co.uk/nucleus/demo/index.html?path=/story/examples-panels--lockup-video-panel](https://britishgas.co.uk/nucleus/demo/index.html?path=/story/examples-panels--lockup-video-panel).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -88,11 +88,11 @@ module.exports = {
           items: [
             {
               label: 'Nucleus',
-              to: 'https://www.britishgas.co.uk/nucleus/demo/index.html?path=/story/playground-cards--all-of-the-cards',
+              to: 'https://www.britishgas.co.uk/nucleus/demo/index.html',
             },
             {
               label: 'Nucleus experiences',
-              href: 'https://www.britishgas.co.uk/nucleus-experiences/demo/index.html?path=/story/nsx-address-selector--anonymous',
+              href: 'https://www.britishgas.co.uk/nucleus-experiences/demo/index.html',
             },
           ],
         },


### PR DESCRIPTION
## What has been completed?
<!-- Provide a list of details of what is included in this pull request. -->

- [x] Rename "playground" to "examples" in Documentation

## Related tickets

- [EPIC 2116](https://github.com/ConnectedHomes/nucleus/issues/2116)