### PR TITLE
fix broken links

### DIFF
--- a/docs/components/ns-card.md
+++ b/docs/components/ns-card.md
@@ -164,7 +164,7 @@ More details on how to use the ns-pill can be found on the [ns-pill documentatio
 ### CTA
 
 * Only for `section` types
-* This should be an anchor with the [ns-cta](https://docs.britishgas.design/components/ns-cta) or just the [ns-cta](https://docs.britishgas.design/components/ns-cta)
+* This should be an anchor with the [ns-cta](../components/ns-cta) or just the [ns-cta](../components/ns-cta)
 
 <Tokens component="card"></Tokens>
 

--- a/docs/components/ns-cta.md
+++ b/docs/components/ns-cta.md
@@ -73,7 +73,7 @@ You can see the live example of the loading state on [storybook](https://www.bri
 | :--- | :--- | :--- | :--- | :--- |
 | `type`    | `string` | `direct` | `direct`, `text` | Different variants of the CTA. |
 | `href` | `string` |           || Linking to another location. |
-| `icon`  | `string` | `arrow-right` | `arrow-left`, `arrow-right` See [`ns-icon` component](https://britishgas.design/components/ns-icon) | The icon inside the CTA |
+| `icon`  | `string` | `arrow-right` | `arrow-left`, `arrow-right` See [`ns-icon` component](../components/ns-icon) | The icon inside the CTA |
 | `loading` | `string` | `false` | `true`, `false` | Change the state of the CTA for loading. |
 | `loadingMessage` | `string` | `Loading...` |  | Overwrites the CTA anonymous slot for the loading state. |
 

--- a/docs/components/ns-expander.md
+++ b/docs/components/ns-expander.md
@@ -45,7 +45,7 @@ An expander consists of a heading and a anonymous content slot.  When the headin
 | :--- | :--- | :--- | :--- | :--- |
 | `type` | `string` | `standard` | `skyline`, `standard` | Variants for the expander. |
 | `open` | `string` | `false` | `true`, `false` | If true will open the expander to show the content. |
-| `icon` | `string` |  | `info`, `warning`. See [`ns-icon` component](https://britishgas.design/components/ns-icon) | Only use for a `type` of `skyline` |
+| `icon` | `string` |  | `info`, `warning`. See [`ns-icon` component](../components/ns-icon) | Only use for a `type` of `skyline` |
 | `colour` | `string` |  | `yellow` | Sets the colour for the heading - Only use for a `type` of `standard` |
 
 | Slots | Type |

--- a/docs/components/ns-pill.md
+++ b/docs/components/ns-pill.md
@@ -68,7 +68,7 @@ A `red` or `green-light` pill can be used to drawing attention to important cust
 | Attribute | Type | Default | Options | Description |
 | :--- | :--- | :--- | :--- |-------------|
 | `colour` | `string` | `slate` |  `slate`, `yellow`, `red`, `green-light` | The colour of the pill |
-| `icon` | `string` |  |  See [`ns-icon` component icon types](https://britishgas.design/components/ns-icon) | The icon to show inside the pill |
+| `icon` | `string` |  |  See [`ns-icon` component icon types](../components/ns-icon) | The icon to show inside the pill |
 
 ## Specification notes
 

--- a/docs/components/ns-tab.md
+++ b/docs/components/ns-tab.md
@@ -40,7 +40,7 @@ Please see [ns-tabs](components/ns-tabs.md) for full content guidance.
 
 | Attribute | Type | Default | Options | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| `icon`    | `string` |  | Please see the [documentation for ns-icon](https://britishgas.design/components/ns-icon) | Optional icon to add to the tab. |
+| `icon`    | `string` |  | Please see the [documentation for ns-icon](../components/ns-icon) | Optional icon to add to the tab. |
 | `selected` | `boolean` | `false` |`true`, `false`| Pre-selected tab |
 
 | Event | Description |

--- a/docs/components/ns-tabs.md
+++ b/docs/components/ns-tabs.md
@@ -52,7 +52,7 @@ A close relationship exists between `ns-tab` and `ns-panel`. Within `ns-tabs` a 
 
 | Attribute | Type | Default | Options | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| `icon`    | `string` |  | Please see the [documentation for ns-icon](https://britishgas.design/components/ns-icon) | Optional icon to add to the tab. |
+| `icon`    | `string` |  | Please see the [documentation for ns-icon](../components/ns-icon) | Optional icon to add to the tab. |
 | `selected` | `boolean` | `false` |`true`, `false`| Pre-selected tab |
 
 | Event | Description |


### PR DESCRIPTION
- Fixed broken component documentation link for ns-icon.
- Fixed component link to refer same environment (dev / staging / live).