### PR TITLE
Fix typo - isrequired to isRequired

### DIFF
--- a/docs/components/ns-inputter.md
+++ b/docs/components/ns-inputter.md
@@ -171,7 +171,7 @@ The following is a list of validation types that `<ns-inputter>` supports. These
 
 |  **Validation type**  | **Usage** |
 | :--- | :--- |
-| `isrequired` | value must be completed |
+| `isRequired` | value must be completed |
 | `isNumber` | value must be a number | 
 | `isInteger`| value must be a whole number with no decimal point | 
 | `isPostcode(includeEIR)` | value must be a valid UK or Ireland postcode |


### PR DESCRIPTION
As per - [Conversation](https://teams.microsoft.com/l/message/19:cc70fa9901014055adaa6a6818dfaa52@thread.tacv2/1626435121889?tenantId=a603898f-7de2-45ba-b67d-d35fb519b2cf&groupId=1f9c2411-216b-42a8-9bb0-c51f28ff5071&parentMessageId=1626435121889&teamName=Nucleus%20Design%20System%20%E2%9A%9B&channelName=Engineering%20support&createdTime=1626435121889)

Fix typo - `isrequired` => `isRequired`