### PR TITLE
Fix/hide Content guidance `<thead>`

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -245,7 +245,7 @@ h1 {
     }
   }
 
-  [id^="key"] + table thead {
+  :has([id^="key"]) + table thead {
     display: none; /* [1] */
   }
 


### PR DESCRIPTION
- [x] hide `thead` following a 'Key' heading