### PR TITLE
feat: add icon & illustration asset and options mapping

### DIFF
--- a/src/components/specification.astro
+++ b/src/components/specification.astro
@@ -77,7 +77,7 @@ const events = compDetails?.events;
                 && (
                   <div>
                     <dt>Options</dt>
-                    <dd>Refer <a href="/guidelines/assets/#icons">icons library</a> for the list of avaiable icons.</dd>
+                    <dd>Refer to our <a href="/guidelines/assets/#icons">icons</a>.</dd>
                   </div>
                 )
               }

--- a/src/components/specification.astro
+++ b/src/components/specification.astro
@@ -55,10 +55,41 @@ const events = compDetails?.events;
                 </div>
                 )
               }
-              <div>
-                <dt>Type</dt>
-                <dd>{property.type?.split('|')?.map((type) => <span><code>{type.replaceAll('"','')}</code>&#32;</span>)}</dd>
-              </div>
+              {
+                property.type?.indexOf('|') > -1 ? (
+                  <div>
+                    <dt>Type</dt>
+                    <dd><span><code>string</code>&#32;</span></dd>
+                  </div>
+                  <div>
+                    <dt>Options</dt>
+                    <dd>{property.type?.split('|')?.map((type) => <span><code>{type.replaceAll('"','')}</code>&#32;</span>)}</dd>
+                  </div>
+                ) : (
+                  <div>
+                    <dt>Type</dt>
+                    <dd>{property.type ? <span><code>{property.type.replaceAll('"','')}</code>&#32;</span> : <> </>} </dd>
+                  </div>
+                )
+              }
+              {
+                (property.name === 'icon' || (name === 'ns-icon' && property.name === 'name') || (property.description?.includes('icon'))) 
+                && (
+                  <div>
+                    <dt>Options</dt>
+                    <dd>Refer <a href="/guidelines/assets/#icons">icons library</a> for the list of avaiable icons.</dd>
+                  </div>
+                )
+              }
+              {
+                (property.name === 'illustration' || (name === 'ns-illustration' && property.name === 'name') || (property.description?.includes('illustration'))) 
+                && (
+                  <div>
+                    <dt>Options</dt>
+                    <dd>Refer <a href="/guidelines/assets/#illustrations">illustrations library</a> for the list of avaiable illustrations.</dd>
+                  </div>
+                )
+              }
               {
                 property.default && (
                   <div>

--- a/src/components/specification.astro
+++ b/src/components/specification.astro
@@ -86,7 +86,7 @@ const events = compDetails?.events;
                 && (
                   <div>
                     <dt>Options</dt>
-                    <dd>Refer <a href="/guidelines/assets/#illustrations">illustrations library</a> for the list of avaiable illustrations.</dd>
+                    <dd>Refer to our <a href="/guidelines/assets/#illustrations">illustrations</a>.</dd>
                   </div>
                 )
               }


### PR DESCRIPTION
- [x] Display predefined types as options in spec table.
- [x] Add reference to icon and illustration assets in spec table.