### PR TITLE
feat: organise left nav

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -154,12 +154,12 @@ export default defineConfig({
           collapsed: true,
           autogenerate: { directory: "guidelines" },
         },
+        componentSidebar(),
         {
           label: "Patterns",
           collapsed: true,
           autogenerate: { directory: "patterns" },
         },
-        componentSidebar(),
         {
           label: "Page types",
           collapsed: true,

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -137,7 +137,7 @@ export default defineConfig({
         PageTitle: "./src/components/starlight/PageTitle.astro",
         PageSidebar: "./src/components/starlight/PageSidebar.astro",
         TableOfContents: "./src/components/starlight/TableOfContents.astro",
-        // ThemeSelect: './src/components/starlight/ThemeSelect.astro',
+        ThemeSelect: './src/components/starlight/ThemeSelect.astro',
         TwoColumnContent: "./src/components/starlight/TwoColumnContent.astro",
         Sidebar: "./src/components/starlight/Sidebar.astro"
       },
@@ -145,7 +145,10 @@ export default defineConfig({
         themes: ["github-dark", "github-light"],
       },
       sidebar: [
-        componentSidebar(),
+        {
+          label: "Introduction",
+          link: '/introduction'
+        },
         {
           label: "Guidelines",
           collapsed: true,
@@ -156,6 +159,7 @@ export default defineConfig({
           collapsed: true,
           autogenerate: { directory: "patterns" },
         },
+        componentSidebar(),
         {
           label: "Page types",
           collapsed: true,

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -457,14 +457,18 @@ main {
 
     > li {
       margin-block-start: 0;
+
+      &:has(> a){
+        border-inline-start-style: none;
+        margin-inline-start: var(--sl-sidebar-item-padding-inline);
+        padding-inline-start: var(--sl-sidebar-item-padding-inline);
+      }
     }
   }
 
-  .group-label {
-    .large {
-      font-weight: 500;
-      color: var(--sl-color-gray-3);
-    }
+  .large {
+    font-weight: 500;
+    color: var(--sl-color-gray-3);
   }
 
   details {
@@ -482,36 +486,36 @@ main {
         }
       }
     }
+  }
 
-    a {
-      position: relative;
-      font-size: var(--sl-text-base);
-      display: block;
-      border-radius: 0.25rem;
-      padding-inline-start: 1rem;
-      padding-inline-end: 0.5rem;
-      padding-block-start: 0.5rem;
-      padding-block-end: 0.5rem;
+  a {
+    position: relative;
+    font-size: var(--sl-text-base);
+    display: block;
+    border-radius: 0.25rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-block-end: 0.5rem;
 
-      &:hover {
-        color: var(--sl-color-white);
-      }
+    &:hover {
+      color: var(--sl-color-white);
+    }
 
-      &[aria-current="page"] {
-        font-weight: 400;
-        background-color: var(--sl-color-gray-6);
-        color: var(--sl-color-text);
+    &[aria-current="page"] {
+      font-weight: 400;
+      background-color: var(--sl-color-gray-6);
+      color: var(--sl-color-text);
 
-        &::before {
-          content: "";
-          position: absolute;
-          top: 0.25rem;
-          bottom: 0.25rem;
-          left: -1rem;
-          width: 0.25rem;
-          background-color: var(--sl-color-accent);
-          border-radius: 0.25rem;
-        }
+      &::before {
+        content: "";
+        position: absolute;
+        top: 0.25rem;
+        bottom: 0.25rem;
+        left: -1rem;
+        width: 0.25rem;
+        background-color: var(--sl-color-accent);
+        border-radius: 0.25rem;
       }
     }
   }


### PR DESCRIPTION
- [x] Add intro page to left nav.
- [x] Reorder `Components` and `Guidelines` in left nav.
- [x] Disable `Theme` switcher.
