### PR TITLE
do-dont-ns-icon

### DIFF
--- a/src/content/docs/components/ns-icon.mdx
+++ b/src/content/docs/components/ns-icon.mdx
@@ -31,9 +31,9 @@ Icons provide clarity to users and reduce their cognitive load. Icons always sup
 :::
 
 :::dont
-- Create your own icons.
-- Add them as content.
-- Use a mix of outline and solid icons.
+- Create new icons without following the proposal process.
+- Add icons as content.
+- Use a random mix of outline and solid icons.
 :::
 
 ## Implementation


### PR DESCRIPTION
Updated to third person, reworded a point about not creating your own icons to one that implies it can be done if you follow due process. Added the word random to the last point as some icons can be used in a mix of outline and solid in some collective contexts such as ns-timeline event statuses. 

Question on the 'use them in colours' statement - is this correct? Colours usually assigned at component level and not configurable?