### PR TITLE
do-dont-ns-product-card

### DIFF
--- a/src/content/docs/components/ns-product-card.mdx
+++ b/src/content/docs/components/ns-product-card.mdx
@@ -24,12 +24,12 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 :::do
 - Use for products.
 - Use the same sections for all products in a group.
-- Give multiple cards the same html parent.
+- Give multiple cards the same HTML parent.
 - Use `role="list"` and `role="listitem"` when used in multiples.
 :::
 
 :::dont
-- Use for other content types, use [`<ns-card>`](/components/ns-card) instead.
+- Use for other content types - use [`<ns-card>`](/components/ns-card) instead.
 - Use in a form.
 - Use different ratio images across a set of multiple cards.
 - Overuse the keyline - its purpose is to make that card stand out from others.


### PR DESCRIPTION
Capitalised the abbreviation, and used the common method of a hyphen for joining the 2 parts of a don't statement. 

Question: We highlight not to overuse the keyline (last point) but in the guidance images we show it multiple times - I recommend updating that image.