### PR TITLE
do-dont-ns-timeline

### DIFF
--- a/src/content/docs/components/ns-timeline.mdx
+++ b/src/content/docs/components/ns-timeline.mdx
@@ -31,16 +31,16 @@ The timeline gives an overview of a process and can show the progression of a cu
 
 :::do
 - Use a maximum of 10 steps.
-- Consider if the title duplicates page title.
+- Consider if the timeline heading duplicates the page heading.
 - Provide helpful messaging.
-- Use summary to set expectations for the `standard` type.
+- Use `summary` and `show-step-count` to help set expectations for the `standard` type.
 :::
 
 :::dont
 - Add too much detailed content.
-- Use illustrations or icons in additional content.
-- Use overly long event names.
-- Use timestamp if it causes confusion with a date elsewhere on the page for the `standard` type.
+- Use illustrations or icons within additional content.
+- Use excessively long event names.
+- Use the timestamp if it causes confusion with a date elsewhere on the page.
 :::
 
 ### Standard


### PR DESCRIPTION
Updated the word 'title' to 'heading', clarified and corrected parts. I made the last Don't more concise. Question on timestamp  - is this just timeline-event specific? If so, perhaps we should only refer to it there.