### PR TITLE
chore: update nucleus version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -695,9 +695,9 @@
       }
     },
     "node_modules/@connectedhomes/nucleus": {
-      "version": "3.3.4",
-      "resolved": "https://npm.pkg.github.com/download/@ConnectedHomes/nucleus/3.3.4/677123d3227d89db66493ef762f47e2d58d59cf7",
-      "integrity": "sha512-o8HhleyXJ8jS4ZtwGGzYw8HnTG7wC3pxRnsKAY5AOR0R74PotTGzAy2XCnTWsGsh8+Itcmk1fFB8QhINFRjdiw==",
+      "version": "3.4.6",
+      "resolved": "https://npm.pkg.github.com/download/@ConnectedHomes/nucleus/3.4.6/8b92084b5f24e1d400fab061928f488cbd0e834d",
+      "integrity": "sha512-B7XQ0zzB4iIYNV5QRyqDl8FsI+v9Km9JUtfujPLvJ2DOZAC/grJ07/nzT/qrzdpo4rWK8PrBA4Y+V37OaP9nFw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.13.0"


### PR DESCRIPTION
- update nucleus version to 3.4.6 to get updated jsdocs