### PR TITLE
[Docs] fix: remove unnecessary span from heading slot

### DIFF
--- a/src/assets/components/ns-landmark/hillside.html
+++ b/src/assets/components/ns-landmark/hillside.html
@@ -1,7 +1,5 @@
 <ns-landmark type="hillside" decoration="cyan">
-  <h1 slot="heading">
-    <span>Neutral milk hotel?</span>
-  </h1>
+  <h1 slot="heading">Neutral milk hotel?</h1>
   <div slot="paragraph">
     <p>Tacos narwhal locavore humblebrag <strong>irony subway</strong> tile cold-pressed everyday carry tofu sartorial.</p>
   </div>

--- a/src/assets/components/ns-landmark/lakeside.html
+++ b/src/assets/components/ns-landmark/lakeside.html
@@ -1,7 +1,5 @@
 <ns-landmark type="lakeside">
-  <h1 slot="heading">
-    <span>Solarpunk shoreditch tumblr</span>
-  </h1>
+  <h1 slot="heading">Solarpunk shoreditch tumblr</h1>
   <div slot="paragraph">
     <p>Lomo pitchfork <strong>street art enamel pin</strong> pok pok lo-fi normcore keffiyeh.</p>
     <p>Skateboard four pound toast cornhole keytar man bun hell of waistcoat sartorial.</p>

--- a/src/assets/components/ns-landmark/standard.html
+++ b/src/assets/components/ns-landmark/standard.html
@@ -1,7 +1,5 @@
 <ns-landmark image="/placeholder-16x9-1440x810px.webp">
-  <h1 slot="heading">
-    <span>Baby tattooed gorpcore portland</span>
-  </h1>
+  <h1 slot="heading">Baby tattooed gorpcore portland</h1>
   <div slot="paragraph">
     <p>Gentrify sus drinking vinegar cred sriracha raclette cardigan. Migas artisan selvage intelligentsia typewriter chicharrones unicorn.</p>
   </div>

--- a/src/assets/components/ns-landmark/summit.html
+++ b/src/assets/components/ns-landmark/summit.html
@@ -1,7 +1,5 @@
 <ns-landmark type="summit" image="/placeholder-16x9-1440x810px.webp">
-  <h1 slot="heading">
-    <span>Cliche narwhal banjo knausgaard</span>
-  </h1>
+  <h1 slot="heading">Cliche narwhal banjo knausgaard</h1>
   <div slot="paragraph">
     <p>Sartorial lomo paleo synth marfa pour-over vibecession mumblecore humblebrag actually.</p>
   </div>

--- a/src/assets/components/ns-landmark/valley.html
+++ b/src/assets/components/ns-landmark/valley.html
@@ -1,7 +1,5 @@
 <ns-landmark type="valley" image="/placeholder-4x3-720x540px.webp">
-  <h1 slot="heading">
-    <span>Paleo synth marfa pour-over vibecession</span>
-  </h1>
+  <h1 slot="heading">Paleo synth marfa pour-over vibecession</h1>
   <ns-pill slot="pill" icon="rewards">Tile raclette</ns-pill>
   <div slot="paragraph">
     <p>Normcore tumblr godard mumblecore typewriter vinyl ascot fanny pack gochujang man braid ugh kinfolk try-hard succulents.</p>


### PR DESCRIPTION
Remove the unnecessary `<span>` from heading slot in the landmark assets.