### PR TITLE
Feat/777 integrate jsdocs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@astrojs/markdown-remark": "^4.2.0",
         "@astrojs/starlight": "^0.15.0",
         "@astrojs/starlight-docsearch": "^0.1.0",
-        "@connectedhomes/nucleus": "^3.22.0",
+        "@connectedhomes/nucleus": "^3.29.0",
         "@connectedhomes/nucleus-snowflakes": "^1.0.1",
         "@connectedhomes/nucleus-util": "^1.11.0",
         "@fontsource/roboto": "^5.0.8",
@@ -615,9 +615,9 @@
       }
     },
     "node_modules/@connectedhomes/nucleus": {
-      "version": "3.28.3",
-      "resolved": "https://npm.pkg.github.com/download/@ConnectedHomes/nucleus/3.28.3/12f6d68f554871ff84035a06414e9719dc01c6df",
-      "integrity": "sha512-PWV6rYFZs6bE2GLzW/iNf79jOqycm/Yw5cjaqMCkHwD7Unj06WGpMUOcOmXe42T0RgnE18PHLqjEQvOpFwctVQ==",
+      "version": "3.29.0",
+      "resolved": "https://npm.pkg.github.com/download/@ConnectedHomes/nucleus/3.29.0/91114b6079da73266e21ab5610b3cc2052bb994f",
+      "integrity": "sha512-vOiyeslHsvBI6YFTGCZcfvlzGh5CMXy4S+lmL8ftyCT/N5lUbKolGsze1oer4ZSEEL4ZwGx8PMzWgEuQFAR4nw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.13.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@astrojs/markdown-remark": "^4.2.0",
     "@astrojs/starlight": "^0.15.0",
     "@astrojs/starlight-docsearch": "^0.1.0",
-    "@connectedhomes/nucleus": "^3.22.0",
+    "@connectedhomes/nucleus": "^3.29.0",
     "@connectedhomes/nucleus-snowflakes": "^1.0.1",
     "@connectedhomes/nucleus-util": "^1.11.0",
     "@fontsource/roboto": "^5.0.8",

--- a/src/content/docs/components/ns-control.mdx
+++ b/src/content/docs/components/ns-control.mdx
@@ -5,8 +5,16 @@ title: Control
 export const componentName = "ns-control";
 
 import CompDetails from '@components/cem-description.astro';
+import Placement from '@components/placement.astro';
+import Specification from '@components/specification.astro';
 
 ## Overview
 
 <CompDetails name={componentName} />
+
+## Implementation
+
+### Specification
+
+<Specification name={componentName} />
 

--- a/src/content/docs/components/ns-control.mdx
+++ b/src/content/docs/components/ns-control.mdx
@@ -1,0 +1,12 @@
+---
+title: Control
+---
+
+export const componentName = "ns-control";
+
+import CompDetails from '@components/cem-description.astro';
+
+## Overview
+
+<CompDetails name={componentName} />
+


### PR DESCRIPTION
# Bump version of Nucleus and integrate JSDocs

This PR contains the bare bones to see the `ns-control` component in the docs after upgrading Nucleus. 

## Summary of changes
### Bump Nucleus version
- package-lock.json
- package.json

### Check JSDocs (minimum doc content)
- src/content/docs/components/ns-control.mdx