### PR TITLE
[Docs] add badge data file description

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ The available aside types are currently as follows:
 ### Adding a badge
 
 Badges are managed by a JSON file (src > data > badges.json) for simple badge management.
+
 Badges can be added to `components`, `assets` or `tokens`.
+
+To retain the affordance, only display badges that are relevant to the last two minor (feature) releases.
 
 ```json
 {

--- a/src/data/badge.json
+++ b/src/data/badge.json
@@ -1,4 +1,5 @@
 {
+  "description": "Nucleus component badges indicating any components that have been updated in the last 2 releases.",
   "components": [
     {
       "name": "ns-download",

--- a/src/data/badge.json
+++ b/src/data/badge.json
@@ -1,5 +1,5 @@
 {
-  "description": "Nucleus component badges indicating any components that have been updated in the last 2 releases.",
+  "description": "See documentation: https://github.com/centrica-engineering/nucleus-docs#adding-a-badge",
   "components": [
     {
       "name": "ns-download",

--- a/src/data/badge.json
+++ b/src/data/badge.json
@@ -1,5 +1,5 @@
 {
-  "description": "See documentation: https://github.com/centrica-engineering/nucleus-docs#adding-a-badge",
+  "description": "See documentation in 'Adding a badge' section of README.md for information.",
   "components": [
     {
       "name": "ns-download",


### PR DESCRIPTION
## What is completed?

This PR adds documentation to the `badge.json` file by including a description field that explains the purpose and usage policy for component badges.