### PR TITLE
bump nucleus and nucleus-util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@astrojs/starlight-docsearch": "^0.1.0",
         "@connectedhomes/nucleus": "^3.34.0",
         "@connectedhomes/nucleus-snowflakes": "^1.0.1",
-        "@connectedhomes/nucleus-util": "^1.11.0",
+        "@connectedhomes/nucleus-util": "^1.24.0",
         "@fontsource/roboto": "^5.0.8",
         "@lit/task": "^1.0.0",
         "@webcomponents/template-shadowroot": "^0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -615,9 +615,9 @@
       }
     },
     "node_modules/@connectedhomes/nucleus": {
-      "version": "3.34.0",
-      "resolved": "https://npm.pkg.github.com/download/@ConnectedHomes/nucleus/3.34.0/caedaeaedcacba4b369b1a7f76ce753c8b5b09d3",
-      "integrity": "sha512-pqjFWqqDpkMUvW+aMM3ZmHwXFQBfXzQbWOcr/XevfqVbMhFSLJpyUbdHXfJ0pqp1NIKnXmOgtQDYHH1KhEfwNw==",
+      "version": "3.34.1",
+      "resolved": "https://npm.pkg.github.com/download/@ConnectedHomes/nucleus/3.34.1/028021ba423098fe3b50e6ff784f1c621a7a75aa",
+      "integrity": "sha512-qexhjcRD6xlZC+/DnbuDG2sBM8O26kQQNJ7Z7FrOvJSL4yBcbji3MUTq5EjbIeLbikP7G/F9I3zttYXVY4/EJA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.13.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@astrojs/markdown-remark": "^4.2.0",
         "@astrojs/starlight": "^0.15.0",
         "@astrojs/starlight-docsearch": "^0.1.0",
-        "@connectedhomes/nucleus": "^3.30.0",
+        "@connectedhomes/nucleus": "^3.34.0",
         "@connectedhomes/nucleus-snowflakes": "^1.0.1",
         "@connectedhomes/nucleus-util": "^1.11.0",
         "@fontsource/roboto": "^5.0.8",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@astrojs/starlight-docsearch": "^0.1.0",
     "@connectedhomes/nucleus": "^3.34.0",
     "@connectedhomes/nucleus-snowflakes": "^1.0.1",
-    "@connectedhomes/nucleus-util": "^1.11.0",
+    "@connectedhomes/nucleus-util": "^1.24.0",
     "@fontsource/roboto": "^5.0.8",
     "@lit/task": "^1.0.0",
     "@webcomponents/template-shadowroot": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@astrojs/markdown-remark": "^4.2.0",
     "@astrojs/starlight": "^0.15.0",
     "@astrojs/starlight-docsearch": "^0.1.0",
-    "@connectedhomes/nucleus": "^3.30.0",
+    "@connectedhomes/nucleus": "^3.34.0",
     "@connectedhomes/nucleus-snowflakes": "^1.0.1",
     "@connectedhomes/nucleus-util": "^1.11.0",
     "@fontsource/roboto": "^5.0.8",


### PR DESCRIPTION
This pull request updates dependencies in the `package.json` file to bring in newer versions of certain packages. There are no code changes, just dependency version bumps.

Dependency updates:

* Bumped `@connectedhomes/nucleus` from version `^3.30.0` to `^3.34.0` to include the latest features and fixes.
* Bumped `@connectedhomes/nucleus-util` from version `^1.11.0` to `^1.24.0` for up-to-date utility functions.