### PR TITLE
docs: update illustration blacklist to remove gauge entries

### DIFF
--- a/src/data/blacklist.json
+++ b/src/data/blacklist.json
@@ -1,6 +1,6 @@
 {
   "blacklist": {
     "icon": [],
-    "illustration": ["ai", "gauge-left", "gauge-right", "gauge-middle", "gauge-neutral" ]
+    "illustration": ["ai"]
   }
 }


### PR DESCRIPTION
This pull request makes a small update to the `src/data/blacklist.json` file, removing all the gauge illustrations.